### PR TITLE
Bugfix/#18334 registered in consul with wrong port and ip

### DIFF
--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -103,11 +103,13 @@ end
 
 action :register do
   begin
+    ipaddress = new_resource.ipaddress
+
     unless node['redborder-ai']['registered']
       query = {}
       query['ID'] = "redborder-ai-#{node['hostname']}"
       query['Name'] = 'redborder-ai'
-      query['Address'] = "#{node['ipaddress']}"
+      query['Address'] = ipaddress
       query['Port'] = 50505
       json_query = Chef::JSONCompat.to_json(query)
 
@@ -119,7 +121,7 @@ action :register do
       node.normal['redborder-ai']['registered'] = true
       Chef::Log.info('redborder-ai service has been registered to consul')
     end
-  rescue => e
+  rescue StandardError => e
     Chef::Log.error(e.message)
   end
 end

--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -108,7 +108,7 @@ action :register do
       query['ID'] = "redborder-ai-#{node['hostname']}"
       query['Name'] = 'redborder-ai'
       query['Address'] = "#{node['ipaddress']}"
-      query['Port'] = 5000
+      query['Port'] = 50505
       json_query = Chef::JSONCompat.to_json(query)
 
       execute 'Register service in consul' do

--- a/resources/resources/config.rb
+++ b/resources/resources/config.rb
@@ -7,3 +7,4 @@ default_action :add
 attribute :user, kind_of: String, default: 'redborder-ai'
 attribute :cdomain, kind_of: String, default: 'redborder.cluster'
 attribute :ai_selected_model, kind_of: String
+attribute :ipaddress, kind_of: String, default: '127.0.0.1'


### PR DESCRIPTION
## Related issue in RedMine

[https://redmine.redborder.lan/issues/18334](https://redmine.redborder.lan/issues/18334)

## Description / Motivation

The service was registering in consul on port 5000 instead of 50505.  
Modified the ipaddress in case there is a sync address